### PR TITLE
Create a Stream with a given device; DeviceBuffer should use the stream's device

### DIFF
--- a/src/ffi/memory/device.rs
+++ b/src/ffi/memory/device.rs
@@ -35,7 +35,8 @@ unsafe impl<T: Copy> Sync for DeviceBuffer<T> {}
 
 impl<T: Copy> DeviceBuffer<T> {
     pub fn new(num_elements: usize, stream: &Stream) -> Self {
-        let device = Device::get_or_panic();
+        Device::set_or_panic(stream.device());
+        let device = stream.device();
         let mut ptr: *mut std::ffi::c_void = std::ptr::null_mut();
         let ptr_ptr = std::ptr::addr_of_mut!(ptr);
         let size = num_elements * std::mem::size_of::<T>();

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,5 +1,6 @@
 use crate::ffi;
 use crate::runtime::{Future, SynchronizeFuture};
+use crate::device::DeviceId;
 
 type Result<T> = std::result::Result<T, crate::error::Error>;
 
@@ -36,6 +37,17 @@ impl Stream {
     /// [CUDA documentation](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g6a3c4b819e6a994c26d0c4824a4c80da)
     pub async fn new() -> Result<Self> {
         let inner = Future::new(ffi::stream::Stream::new).await?;
+        Ok(Self { inner })
+    }
+
+    /// Create an asynchronous stream with a given device.
+    ///
+    /// [CUDA documentation](https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__STREAM.html#group__CUDART__STREAM_1g6a3c4b819e6a994c26d0c4824a4c80da)
+    pub async fn with_device(device: DeviceId) -> Result<Self> {
+        let inner = Future::new(|| {
+            ffi::device::Device::set_or_panic(device);
+            ffi::stream::Stream::new()
+        }).await?;
         Ok(Self { inner })
     }
 


### PR DESCRIPTION
On systems with multiple GPUs you can end up in situations where an `aync_cuda::Future` is running on the wrong device. If you try to create a Stream like so:

```
Device::set(self.gpu_id as i32).await?;
let stream = Stream::new().await?;
```

It's possible that a race can occur, another thread can change the device right after you set it, and then your stream is on the wrong the GPU. This PR adds a function that sets the gpu and creates the stream in the same `Future`, removing the race. It also fixes an issue in `DeviceBuffer`, where the `DeviceBuffer` may create an invalid allocation because the stream's device id and the context device id's don't match.